### PR TITLE
Fix redirect when session auth fails

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -39,7 +39,7 @@ func (h *Handler) SessionAuth(c *gin.Context) {
 	cookie, err := c.Cookie("userId")
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusUnauthorized, gin.H{"status": "unauthorized"})
+		c.JSON(http.StatusMovedPermanently, "/login")
 		c.Abort()
 		return
 	}
@@ -47,7 +47,7 @@ func (h *Handler) SessionAuth(c *gin.Context) {
 	user, err := h.dbClient.FindUserByUsername(cookie)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusUnauthorized, gin.H{"status": "unauthorized"})
+		c.JSON(http.StatusMovedPermanently, "/login")
 		c.Abort()
 		return
 	}


### PR DESCRIPTION
Resolves the problem of returning only a simple status error and not redirecting when session auth fails.
I just changed the implementation to unconditionally redirect.