### PR TITLE
Update to use environment variables about domain name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       POSTGRES_HOST: postgresql
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: secret
+      DOMAIN: localhost
     restart: always
     ports:
       - 8005:8005

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -10,16 +10,23 @@ import (
 
 type Handler struct {
 	dbClient *database.Client
+	domain   string
 }
 
-func New() *Handler {
+func New(domain string) *Handler {
 	dbClient, err := database.Dial()
 	if err != nil {
 		log.Println(err)
 		return nil
 	}
+
+	if domain == "" {
+		domain = "localhost"
+	}
+
 	return &Handler{
 		dbClient: dbClient,
+		domain:   domain,
 	}
 }
 

--- a/handler/user.go
+++ b/handler/user.go
@@ -49,12 +49,12 @@ func (h *Handler) PostLogin(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"status": "unauthorized"})
 		return
 	}
-	c.SetCookie("userId", userData.Username, 3600, "/", "localhost", false, true)
+	c.SetCookie("userId", userData.Username, 3600, "/", h.domain, false, true)
 	c.JSON(http.StatusOK, gin.H{"status": "login success"})
 }
 
 func (h *Handler) PostLogout(c *gin.Context) {
-	c.SetCookie("userId", "", -1, "/", "localhost", false, true)
+	c.SetCookie("userId", "", -1, "/", h.domain, false, true)
 
 	c.JSON(http.StatusOK, gin.H{"status": "logout success"})
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/GCU-Graduate-Project-Sharpic/Backend/handler"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
@@ -8,7 +10,7 @@ import (
 
 func main() {
 	router := gin.Default()
-	handler := handler.New()
+	handler := handler.New(os.Getenv("DOMAIN"))
 
 	router.GET("/", handler.SessionAuth, static.Serve("/", static.LocalFile("/Frontend", true)))
 	router.Use(static.Serve("/", static.LocalFile("/Frontend", true)))


### PR DESCRIPTION
Until now, the domain name for creating cookies was hard-coded, but change it to use environment variables.
If the environment variable is not set, the default value is localhost.